### PR TITLE
Avoid Diagnosticable mixin error

### DIFF
--- a/panache_ui/lib/src/screens/editor/controls/color_picker/color_slider.dart
+++ b/panache_ui/lib/src/screens/editor/controls/color_picker/color_slider.dart
@@ -1097,7 +1097,7 @@ class _RenderSlider extends RenderBox {
   }
 }
 
-class GradientSliderThemeData extends Diagnosticable {
+class GradientSliderThemeData extends Object with Diagnosticable {
   const GradientSliderThemeData({
     @required this.startRailColor,
     @required this.endRailColor,


### PR DESCRIPTION
Diagnostical is a mixin, so it can't be extended directly. This caused
the build to break on 1.24.0-4.0.pre.109 (master channel)